### PR TITLE
libusb_set_debug is deprecated

### DIFF
--- a/rpiboot/main.c
+++ b/rpiboot/main.c
@@ -617,7 +617,7 @@ int main(int argc, char *argv[])
 		exit(-1);
 	}
 
-	libusb_set_debug(ctx, verbose ? LIBUSB_LOG_LEVEL_WARNING : 0);
+	libusb_set_option(ctx, LIBUSB_OPTION_LOG_LEVEL, verbose ? LIBUSB_LOG_LEVEL_WARNING : 0);
 
 	do
 	{


### PR DESCRIPTION
Had this error when running make in `/rpiboot`:
```
main.c: In function ‘main’:
main.c:620:2: warning: ‘libusb_set_debug’ is deprecated: Use libusb_set_option instead [-Wdeprecated-declarations]
  620 |  libusb_set_debug(ctx, verbose ? LIBUSB_LOG_LEVEL_WARNING : 0);
      |  ^~~~~~~~~~~~~~~~
In file included from main.c:1:
/usr/include/libusb-1.0/libusb.h:1325:18: note: declared here
 1325 | void LIBUSB_CALL libusb_set_debug(libusb_context *ctx, int level);
```

Just changed the function call. This worked for me.